### PR TITLE
Refactored the header and footer of FlexView

### DIFF
--- a/MJRFlexStyleComponents.podspec
+++ b/MJRFlexStyleComponents.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'MJRFlexStyleComponents'
-  s.version          = '1.4'
+  s.version          = '1.5'
   s.license          = 'MIT'
   s.summary          = 'Sliding components and views with style'
   s.homepage         = 'https://github.com/mjrehder/MJRFlexStyleComponents.git'

--- a/MJRFlexStyleComponents.xcodeproj/project.pbxproj
+++ b/MJRFlexStyleComponents.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		5B12A8E41D73066E0072D1E1 /* ImageViewDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B12A8E31D73066E0072D1E1 /* ImageViewDemoViewController.swift */; };
 		5B1EFC7A1D7047250040AD50 /* FlexViewMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1EFC791D7047250040AD50 /* FlexViewMenu.swift */; };
 		5B1EFC7B1D7047250040AD50 /* FlexViewMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1EFC791D7047250040AD50 /* FlexViewMenu.swift */; };
+		5B49AAF31D8E6CB0003C062E /* FlexLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B49AAF21D8E6CB0003C062E /* FlexLabel.swift */; };
+		5B49AAF41D8E6CB0003C062E /* FlexLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B49AAF21D8E6CB0003C062E /* FlexLabel.swift */; };
 		5B53D0F31D5372010068BF04 /* FlexView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B53D0F21D5372010068BF04 /* FlexView.swift */; };
 		5B53D0F41D5372010068BF04 /* FlexView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B53D0F21D5372010068BF04 /* FlexView.swift */; };
 		5B53D0F71D5393520068BF04 /* ViewsDemoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B53D0F51D5393520068BF04 /* ViewsDemoViewController.swift */; };
@@ -70,6 +72,7 @@
 		5B12A8E01D72EBE50072D1E1 /* FlexImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FlexImageView.swift; sourceTree = "<group>"; };
 		5B12A8E31D73066E0072D1E1 /* ImageViewDemoViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageViewDemoViewController.swift; sourceTree = "<group>"; };
 		5B1EFC791D7047250040AD50 /* FlexViewMenu.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FlexViewMenu.swift; sourceTree = "<group>"; };
+		5B49AAF21D8E6CB0003C062E /* FlexLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FlexLabel.swift; sourceTree = "<group>"; };
 		5B53D0F21D5372010068BF04 /* FlexView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FlexView.swift; sourceTree = "<group>"; };
 		5B53D0F51D5393520068BF04 /* ViewsDemoViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewsDemoViewController.swift; sourceTree = "<group>"; };
 		5B6CF1581D48E8DD00291D8B /* MKColor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MKColor.swift; sourceTree = "<group>"; };
@@ -207,6 +210,7 @@
 			children = (
 				5BE448651D474DE20011E5AE /* Helper */,
 				5BF702131D3114CB0011555A /* GenericStyleSlider */,
+				5B49AAF21D8E6CB0003C062E /* FlexLabel.swift */,
 				5BE448521D4381C90011E5AE /* FlexSwitch.swift */,
 				5BE4485C1D44C8D80011E5AE /* FlexMenuItem.swift */,
 				5BE448591D44C71D0011E5AE /* FlexMenu.swift */,
@@ -464,6 +468,7 @@
 				5BEAF3231D6851B600BF5D83 /* MenusDemoViewController.swift in Sources */,
 				5B0859E11D7EE65500484E8F /* FlexTextView.swift in Sources */,
 				5BE4486B1D4760EE0011E5AE /* FlexSlider.swift in Sources */,
+				5B49AAF41D8E6CB0003C062E /* FlexLabel.swift in Sources */,
 				5B9936FF1D3A9E210043E573 /* AppDelegate.swift in Sources */,
 				5BE448541D4381C90011E5AE /* FlexSwitch.swift in Sources */,
 			);
@@ -477,6 +482,7 @@
 				5B9F2C5E1D31616200B096B5 /* SnappingThumbBehaviour.swift in Sources */,
 				5BC4B9B01D520E7F0000421F /* MJRFlexBaseControl.swift in Sources */,
 				5B9936D91D3A578B0043E573 /* StyledControlDirection.swift in Sources */,
+				5B49AAF31D8E6CB0003C062E /* FlexLabel.swift in Sources */,
 				5B0859E01D7EE65500484E8F /* FlexTextView.swift in Sources */,
 				5BE4486A1D4760EE0011E5AE /* FlexSlider.swift in Sources */,
 				5BF702151D3116AC0011555A /* GenericStyleSlider.swift in Sources */,

--- a/MJRFlexStyleComponents/FlexLabel.swift
+++ b/MJRFlexStyleComponents/FlexLabel.swift
@@ -1,0 +1,114 @@
+//
+//  FlexLabel.swift
+//  MJRFlexStyleComponents
+//
+//  Created by Martin Rehder on 18.09.16.
+/*
+ * Copyright 2016-present Martin Jacob Rehder.
+ * http://www.rehsco.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+import UIKit
+import StyledLabel
+
+/// This class wraps a StyledLabel and adds features for placement, layout, etc.
+@IBDesignable
+public class FlexLabel: UIControl {
+    private lazy var _label = LabelFactory.defaultStyledLabel()
+    
+    public var label: StyledLabel {
+        get {
+            return _label
+        }
+    }
+    
+    /// The background color. If nil the color will be clear color. Defaults to nil.
+    @IBInspectable public var labelBackgroundColor: UIColor? {
+        didSet {
+            self.applyStyle(style)
+        }
+    }
+    
+    /// The font of the label
+    @IBInspectable public var labelFont = UIFont(name: "TrebuchetMS-Bold", size: 20) {
+        didSet {
+            self.applyStyle(style)
+        }
+    }
+    
+    /// The text alignment of the label
+    @IBInspectable public var labelTextAlignment: NSTextAlignment = .Center {
+        didSet {
+            self.applyStyle(style)
+        }
+    }
+    
+    /// The text color. Default's to black
+    @IBInspectable public var labelTextColor: UIColor = .blackColor() {
+        didSet {
+            self.applyStyle(style)
+        }
+    }
+    
+    @IBInspectable public var style: ShapeStyle = .Box {
+        didSet {
+            self.applyStyle(style)
+        }
+    }
+    
+    /// The border color.
+    @IBInspectable public var labelBorderColor: UIColor? {
+        didSet {
+            self.applyStyle(style)
+        }
+    }
+    
+    /// The border width. Default's to 1.0
+    @IBInspectable public var labelBorderWidth: CGFloat = 1.0 {
+        didSet {
+            self.applyStyle(style)
+        }
+    }
+    
+    public var labelInsets: UIEdgeInsets = UIEdgeInsetsZero {
+        didSet {
+            self.applyStyle(style)
+        }
+    }
+    
+    func applyStyle(style: ShapeStyle) {
+        if self.label.superview == nil {
+            self.addSubview(self.label)
+        }
+        self.label.style = style
+        self.label.backgroundColor = .clearColor()
+        self.label.borderColor = labelBorderColor
+        self.label.borderWidth = labelBorderWidth
+        self.label.textColor = labelTextColor
+        self.label.font = labelFont
+        self.label.textAlignment = labelTextAlignment
+    }
+    
+    func applyStyle() {
+        self.applyStyle(style)
+    }
+}

--- a/MJRFlexStyleComponents/FlexView.swift
+++ b/MJRFlexStyleComponents/FlexView.swift
@@ -37,8 +37,8 @@ public enum FlexViewHeaderPosition {
 }
 
 public class FlexView: MJRFlexBaseControl {
-    var headerLabel: StyledLabel?
-    var footerLabel: StyledLabel?
+    var headerLabel = FlexLabel()
+    var footerLabel = FlexLabel()
     
     var menus: [FlexViewMenu] = []
     
@@ -79,69 +79,21 @@ public class FlexView: MJRFlexBaseControl {
             layoutComponents()
         }
     }
-
+    
     /// The header text. Defaults to nil, which means no text.
     @IBInspectable public var headerAttributedText: NSAttributedString? = nil {
         didSet {
             layoutComponents()
         }
     }
-
+    
     /// The header size is either the height or the width of the header, depending on the header position. Defaults to 18.
     @IBInspectable public var headerSize: CGFloat = 18.0 {
         didSet {
             layoutComponents()
         }
     }
-    
-    /// The headers background colors. If nil the header color will be clear color. Defaults to nil.
-    @IBInspectable public var headerBackgroundColor: UIColor? {
-        didSet {
-            self.applyHeaderStyle(headerStyle)
-        }
-    }
-    
-    /// The font of the header labels
-    @IBInspectable public var headerFont = UIFont(name: "TrebuchetMS-Bold", size: 20) {
-        didSet {
-            self.applyHeaderStyle(headerStyle)
-        }
-    }
-    
-    /// The text alignment of the header label
-    @IBInspectable public var headerTextAlignment: NSTextAlignment = .Center {
-        didSet {
-            self.applyHeaderStyle(headerStyle)
-        }
-    }
-    
-    /// The headers text colors. Default's to black
-    @IBInspectable public var headerTextColor: UIColor = .blackColor() {
-        didSet {
-            self.applyHeaderStyle(headerStyle)
-        }
-    }
-    
-    @IBInspectable public var headerStyle: ShapeStyle = .Box {
-        didSet {
-            self.applyHeaderStyle(headerStyle)
-        }
-    }
-    
-    /// The headers border color.
-    @IBInspectable public var headerBorderColor: UIColor? {
-        didSet {
-            self.applyHeaderStyle(headerStyle)
-        }
-    }
-    
-    /// The headers border width. Default's to 1.0
-    @IBInspectable public var headerBorderWidth: CGFloat = 1.0 {
-        didSet {
-            self.applyHeaderStyle(headerStyle)
-        }
-    }
-    
+
     /// The header will be clipped to the background shape. Defaults to true.
     @IBInspectable public var headerClipToBackgroundShape: Bool = true {
         didSet {
@@ -172,54 +124,6 @@ public class FlexView: MJRFlexBaseControl {
         }
     }
     
-    /// The footers background color. If nil the footer color will be clear color. Defaults to nil.
-    @IBInspectable public var footerBackgroundColor: UIColor? {
-        didSet {
-            self.applyFooterStyle(footerStyle)
-        }
-    }
-    
-    /// The font of the footer label
-    @IBInspectable public var footerFont = UIFont(name: "TrebuchetMS-Bold", size: 20) {
-        didSet {
-            self.applyFooterStyle(footerStyle)
-        }
-    }
-    
-    /// The text alignment of the footer label
-    @IBInspectable public var footerTextAlignment: NSTextAlignment = .Center {
-        didSet {
-            self.applyFooterStyle(footerStyle)
-        }
-    }
-    
-    /// The footers text colors. Default's to black
-    @IBInspectable public var footerTextColor: UIColor = .blackColor() {
-        didSet {
-            self.applyFooterStyle(footerStyle)
-        }
-    }
-    
-    @IBInspectable public var footerStyle: ShapeStyle = .Box {
-        didSet {
-            self.applyFooterStyle(footerStyle)
-        }
-    }
-    
-    /// The footers border color.
-    @IBInspectable public var footerBorderColor: UIColor? {
-        didSet {
-            self.applyFooterStyle(footerStyle)
-        }
-    }
-    
-    /// The footers border width. Default's to 1.0
-    @IBInspectable public var footerBorderWidth: CGFloat = 1.0 {
-        didSet {
-            self.applyFooterStyle(footerStyle)
-        }
-    }
-
     /// The footer will be clipped to the background shape. Defaults to true.
     @IBInspectable public var footerClipToBackgroundShape: Bool = true {
         didSet {
@@ -274,26 +178,6 @@ public class FlexView: MJRFlexBaseControl {
     }
     
     // MARK: - Private Style
-    
-    func applyHeaderStyle(style: ShapeStyle) {
-        self.headerLabel?.style = style
-        self.headerLabel?.backgroundColor = .clearColor()
-        self.headerLabel?.borderColor = headerBorderColor
-        self.headerLabel?.borderWidth = headerBorderWidth
-        self.headerLabel?.textColor = headerTextColor
-        self.headerLabel?.font = headerFont
-        self.headerLabel?.textAlignment = headerTextAlignment
-    }
-    
-    func applyFooterStyle(style: ShapeStyle) {
-        self.footerLabel?.style = style
-        self.footerLabel?.backgroundColor = .clearColor()
-        self.footerLabel?.borderColor = footerBorderColor
-        self.footerLabel?.borderWidth = footerBorderWidth
-        self.footerLabel?.textColor = footerTextColor
-        self.footerLabel?.font = footerFont
-        self.footerLabel?.textAlignment = footerTextAlignment
-    }
 
     func rectForHeader() -> CGRect {
         switch self.headerPosition {
@@ -332,45 +216,45 @@ public class FlexView: MJRFlexBaseControl {
         super.layoutComponents()
         
         if self.hasHeaderText() {
-            if self.headerLabel == nil {
-                self.headerLabel = LabelFactory.defaultStyledLabel()
-                self.addSubview(self.headerLabel!)
+            if self.headerLabel.superview == nil {
+                self.addSubview(self.headerLabel)
             }
-            self.headerLabel?.frame = self.rectForHeader()
-            self.headerLabel?.transform = self.getHeaderFooterRotation()
-            self.headerLabel?.frame = self.rectForHeader()
+            self.headerLabel.frame = self.rectForHeader()
+            let headerBounds = UIEdgeInsetsInsetRect(self.headerLabel.bounds, self.headerLabel.labelInsets)
+            self.headerLabel.label.frame = headerBounds
+            self.headerLabel.label.transform = self.getHeaderFooterRotation()
+            self.headerLabel.label.frame = headerBounds
             if self.headerText != nil {
-                self.headerLabel?.text = headerText
+                self.headerLabel.label.text = headerText
             }
             else {
-                self.headerLabel?.attributedText = headerAttributedText
+                self.headerLabel.label.attributedText = headerAttributedText
             }
-            applyHeaderStyle(headerStyle)
+            self.headerLabel.applyStyle()
         }
         else {
-            self.headerLabel?.removeFromSuperview()
-            self.headerLabel = nil
+            self.headerLabel.removeFromSuperview()
         }
         
         if self.hasFooterText() {
-            if self.footerLabel == nil {
-                self.footerLabel = LabelFactory.defaultStyledLabel()
-                self.addSubview(self.footerLabel!)
+            if self.footerLabel.superview == nil {
+                self.addSubview(self.footerLabel)
             }
-            self.footerLabel?.frame = self.rectForFooter()
-            self.footerLabel?.transform = self.getHeaderFooterRotation()
-            self.footerLabel?.frame = self.rectForFooter()
+            self.footerLabel.frame = self.rectForFooter()
+            let footerBounds = UIEdgeInsetsInsetRect(self.footerLabel.bounds, self.footerLabel.labelInsets)
+            self.footerLabel.label.frame = footerBounds
+            self.footerLabel.label.transform = self.getHeaderFooterRotation()
+            self.footerLabel.label.frame = footerBounds
             if self.footerText != nil {
-                self.footerLabel?.text = footerText
+                self.footerLabel.label.text = footerText
             }
             else {
-                self.footerLabel?.attributedText = footerAttributedText
+                self.footerLabel.label.attributedText = footerAttributedText
             }
-            applyFooterStyle(footerStyle)
+            self.footerLabel.applyStyle()
         }
         else {
-            self.footerLabel?.removeFromSuperview()
-            self.footerLabel = nil
+            self.footerLabel.removeFromSuperview()
         }
         
         for menu in self.menus {
@@ -384,12 +268,12 @@ public class FlexView: MJRFlexBaseControl {
         let bgsLayer = StyledShapeLayer.createShape(style, bounds: layerRect, color: bgColor)
         
         if self.hasHeaderText() {
-            let headerShapeLayer = StyledShapeLayer.createShape(self.style, bounds: layerRect, shapeStyle: self.headerStyle, shapeBounds: self.rectForHeader().offsetBy(dx: -layerRect.origin.x, dy: -layerRect.origin.y), shapeColor: self.headerBackgroundColor ?? .clearColor(), maskToBounds: self.headerClipToBackgroundShape)
+            let headerShapeLayer = StyledShapeLayer.createShape(self.style, bounds: layerRect, shapeStyle: self.headerLabel.style, shapeBounds: self.rectForHeader().offsetBy(dx: -layerRect.origin.x, dy: -layerRect.origin.y), shapeColor: self.headerLabel.labelBackgroundColor ?? .clearColor(), maskToBounds: self.headerClipToBackgroundShape)
             bgsLayer.addSublayer(headerShapeLayer)
         }
         
         if self.hasFooterText() {
-            let footerShapeLayer = StyledShapeLayer.createShape(self.style, bounds: layerRect, shapeStyle: self.footerStyle, shapeBounds: self.rectForFooter().offsetBy(dx: -layerRect.origin.x, dy: -layerRect.origin.y), shapeColor: self.footerBackgroundColor ?? .clearColor(), maskToBounds: self.footerClipToBackgroundShape)
+            let footerShapeLayer = StyledShapeLayer.createShape(self.style, bounds: layerRect, shapeStyle: self.footerLabel.style, shapeBounds: self.rectForFooter().offsetBy(dx: -layerRect.origin.x, dy: -layerRect.origin.y), shapeColor: self.footerLabel.labelBackgroundColor ?? .clearColor(), maskToBounds: self.footerClipToBackgroundShape)
             bgsLayer.addSublayer(footerShapeLayer)
         }
 

--- a/MJRFlexStyleComponents/Info.plist
+++ b/MJRFlexStyleComponents/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4</string>
+	<string>1.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/MJRFlexStyleExamples/Base.lproj/Main.storyboard
+++ b/MJRFlexStyleExamples/Base.lproj/Main.storyboard
@@ -347,12 +347,6 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5t7-Zh-Gc0" customClass="FlexTextView" customModule="MJRFlexStyleExamples" customModuleProvider="target">
                                 <rect key="frame" x="152" y="72" width="296" height="508"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="headerText" value="This is a FlexTextView"/>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="headerBackgroundColor">
-                                        <color key="value" red="1" green="0.70658557046979864" blue="0.385539010067114" alpha="1" colorSpace="calibratedRGB"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
                             </view>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>

--- a/MJRFlexStyleExamples/FlexTextViewDemoViewController.swift
+++ b/MJRFlexStyleExamples/FlexTextViewDemoViewController.swift
@@ -25,8 +25,8 @@ class FlexTextViewDemoViewController: UIViewController {
         self.flexTextView.headerPosition = .Top
         self.flexTextView.style = .RoundedFixed(cornerRadius: 10.0)
         self.flexTextView.styleColor = UIColor.MKColor.Teal.P50
-        self.flexTextView.headerBackgroundColor = UIColor.MKColor.Teal.P700
-        self.flexTextView.headerFont = UIFont.boldSystemFontOfSize(14)
-        self.flexTextView.headerTextColor = UIColor.whiteColor()
+        self.flexTextView.headerLabel.labelBackgroundColor = UIColor.MKColor.Teal.P700
+        self.flexTextView.headerLabel.labelFont = UIFont.boldSystemFontOfSize(14)
+        self.flexTextView.headerLabel.labelTextColor = UIColor.whiteColor()
     }
 }

--- a/MJRFlexStyleExamples/ImageViewDemoViewController.swift
+++ b/MJRFlexStyleExamples/ImageViewDemoViewController.swift
@@ -59,9 +59,9 @@ class ImageViewDemoViewController: UIViewController, FlexMenuDataSource {
         self.flexView.headerPosition = .Top
         self.flexView.style = .RoundedFixed(cornerRadius: 10.0)
         self.flexView.styleColor = UIColor.MKColor.Teal.P500
-        self.flexView.headerBackgroundColor = UIColor.MKColor.Teal.P700
-        self.flexView.headerFont = UIFont.boldSystemFontOfSize(14)
-        self.flexView.headerTextColor = UIColor.whiteColor()
+        self.flexView.headerLabel.labelBackgroundColor = UIColor.MKColor.Teal.P700
+        self.flexView.headerLabel.labelFont = UIFont.boldSystemFontOfSize(14)
+        self.flexView.headerLabel.labelTextColor = UIColor.whiteColor()
         
         self.flexView.imageView.image = UIImage(named: "DemoImage")
         self.flexView.imageView.contentMode = .ScaleAspectFit

--- a/MJRFlexStyleExamples/Info.plist
+++ b/MJRFlexStyleExamples/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4</string>
+	<string>1.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/MJRFlexStyleExamples/MenusDemoViewController.swift
+++ b/MJRFlexStyleExamples/MenusDemoViewController.swift
@@ -118,9 +118,9 @@ class MenusDemoViewController: UIViewController, FlexMenuDataSource {
         self.flexView.headerPosition = .Top
         self.flexView.style = .RoundedFixed(cornerRadius: 10.0)
         self.flexView.styleColor = UIColor.MKColor.Teal.P500
-        self.flexView.headerBackgroundColor = UIColor.MKColor.Teal.P700
-        self.flexView.headerFont = UIFont.boldSystemFontOfSize(14)
-        self.flexView.headerTextColor = UIColor.whiteColor()
+        self.flexView.headerLabel.labelBackgroundColor = UIColor.MKColor.Teal.P700
+        self.flexView.headerLabel.labelFont = UIFont.boldSystemFontOfSize(14)
+        self.flexView.headerLabel.labelTextColor = UIColor.whiteColor()
         
         self.flexView.addMenu(self.flexViewMenu!)
     }

--- a/MJRFlexStyleExamples/ViewsDemoViewController.swift
+++ b/MJRFlexStyleExamples/ViewsDemoViewController.swift
@@ -25,24 +25,24 @@ class ViewsDemoViewController: UIViewController {
         let cpath = UIBezierPath(roundedRect: self.outerFlexView.bounds, cornerRadius: 10)
         self.outerFlexView.style = .Custom(path: cpath)
         self.outerFlexView.styleColor = UIColor.MKColor.BlueGrey.P100
-        self.outerFlexView.headerBackgroundColor = UIColor.MKColor.BlueGrey.P500
+        self.outerFlexView.headerLabel.labelBackgroundColor = UIColor.MKColor.BlueGrey.P500
         
         self.outerFlexView.headerSize = 22
-        self.outerFlexView.headerFont = UIFont.systemFontOfSize(18)
-        self.outerFlexView.footerFont = UIFont.systemFontOfSize(14)
-        self.outerFlexView.headerTextColor = UIColor.whiteColor()
+        self.outerFlexView.headerLabel.labelFont = UIFont.systemFontOfSize(18)
+        self.outerFlexView.footerLabel.labelFont = UIFont.systemFontOfSize(14)
+        self.outerFlexView.headerLabel.labelTextColor = UIColor.whiteColor()
 
         leftFlexView.headerPosition = .Left
         leftFlexView.backgroundMargins = UIEdgeInsetsMake(0, 20, 0, 0)
         leftFlexView.headerText = "Left"
         leftFlexView.footerText = "Left Footer"
         leftFlexView.styleColor = UIColor.MKColor.Amber.P100
-        leftFlexView.headerBackgroundColor = UIColor.MKColor.Amber.P500
+        leftFlexView.headerLabel.labelBackgroundColor = UIColor.MKColor.Amber.P500
         leftFlexView.headerClipToBackgroundShape = false
         leftFlexView.headerSize = 16
-        leftFlexView.headerFont = UIFont.boldSystemFontOfSize(10)
-        leftFlexView.footerFont = UIFont.systemFontOfSize(10)
-        leftFlexView.headerTextColor = UIColor.whiteColor()
+        leftFlexView.headerLabel.labelFont = UIFont.boldSystemFontOfSize(10)
+        leftFlexView.footerLabel.labelFont = UIFont.systemFontOfSize(10)
+        leftFlexView.headerLabel.labelTextColor = UIColor.whiteColor()
         leftFlexView.style = .Custom(path: UIBezierPath(roundedRect: leftFlexView.bounds, cornerRadius: 10))
         
         rightFlexView.headerPosition = .Right
@@ -50,14 +50,14 @@ class ViewsDemoViewController: UIViewController {
         rightFlexView.headerText = "Right"
         rightFlexView.footerText = "Right Footer"
         rightFlexView.styleColor = UIColor.MKColor.Amber.P100
-        rightFlexView.headerBackgroundColor = UIColor.MKColor.Amber.P500
+        rightFlexView.headerLabel.labelBackgroundColor = UIColor.MKColor.Amber.P500
         rightFlexView.headerSize = 16
-        rightFlexView.headerStyle = .Tube
+        rightFlexView.headerLabel.style = .Tube
         rightFlexView.headerClipToBackgroundShape = false
-        rightFlexView.headerFont = UIFont.boldSystemFontOfSize(10)
-        rightFlexView.footerFont = UIFont.systemFontOfSize(10)
+        rightFlexView.headerLabel.labelFont = UIFont.boldSystemFontOfSize(10)
+        rightFlexView.footerLabel.labelFont = UIFont.systemFontOfSize(10)
         rightFlexView.footerClipToBackgroundShape = false
-        rightFlexView.headerTextColor = UIColor.whiteColor()
+        rightFlexView.headerLabel.labelTextColor = UIColor.whiteColor()
         rightFlexView.style = .Custom(path: UIBezierPath(roundedRect: rightFlexView.bounds, cornerRadius: 10))
 
     }

--- a/README.md
+++ b/README.md
@@ -241,14 +241,14 @@ Example (from the example project):
         rightFlexView.headerText = "Right"
         rightFlexView.footerText = "Right Footer"
         rightFlexView.styleColor = UIColor.MKColor.Amber.P100
-        rightFlexView.headerBackgroundColor = UIColor.MKColor.Amber.P500
+        rightFlexView.headerLabel.labelBackgroundColor = UIColor.MKColor.Amber.P500
         rightFlexView.headerSize = 16
-        rightFlexView.headerStyle = .Tube
+        rightFlexView.headerLabel.style = .Tube
         rightFlexView.headerClipToBackgroundShape = false
-        rightFlexView.headerFont = UIFont.boldSystemFontOfSize(10)
-        rightFlexView.footerFont = UIFont.systemFontOfSize(10)
+        rightFlexView.headerLabel.labelFont = UIFont.boldSystemFontOfSize(10)
+        rightFlexView.footerLabel.labelFont = UIFont.systemFontOfSize(10)
         rightFlexView.footerClipToBackgroundShape = false
-        rightFlexView.headerTextColor = UIColor.whiteColor()
+        rightFlexView.headerLabel.labelTextColor = UIColor.whiteColor()
         rightFlexView.style = .Custom(path: UIBezierPath(roundedRect: rightFlexView.bounds, cornerRadius: 10))
 ```
 


### PR DESCRIPTION
Added insets for headers and footers

Please note, that the headers and footers style is now moved into the headerLabel and footerLabel in the FlexView instead of setting all the properties via the FlexView directly.
